### PR TITLE
[WIP] Add dev Ansible playbooks to install dev environment on fedora

### DIFF
--- a/dev/playbooks/README.md
+++ b/dev/playbooks/README.md
@@ -1,0 +1,36 @@
+SatelliteQE Dev Environment Playbooks
+=====================================
+
+The ansible playbooks to deploy Fedora 23 development machine
+
+install
+--------------
+
+Install Ansible
+
+```bash
+wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
+sudo -H python2 /tmp/get-pip.py -U
+sudo -H pip install ansible
+```
+
+Check
+------
+1. You forked SatelliteQE repositories to your own github account
+    * Go to github and click **fork** button on the following repositories
+        * SatelliteQE/robottelo
+        * SatelliteQE/nailgun
+        * SatelliteQE/automation-tools
+2. You have your ssh-keys configured to access github from your local machine
+    * ```ssh-keygen```  generate a key with defaults, ```cat ~/.ssh/id_rsa.pub``` copy and paste the contents in github (settings/ssh-keys)
+
+Configure
+---------
+Edit **workstation.yml** including your github username and email
+
+Run
+---
+
+```bash
+ansible-playbook workstation.yml --ask-sudo-pass
+```

--- a/dev/playbooks/ansible.cfg
+++ b/dev/playbooks/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+hostfile=./hosts

--- a/dev/playbooks/default_fedora_packages_to_install.yml
+++ b/dev/playbooks/default_fedora_packages_to_install.yml
@@ -1,0 +1,45 @@
+---
+
+packages_to_install:
+    - "@Development Libraries"
+    - aria2
+    - automake
+    - gcc
+    - gcc-c++
+    - kernel-devel
+    - diffstat
+    - doxygen
+    - patch
+    - patchutils
+    - colordiff
+    - meld
+    - qgit
+    - cheese
+    - cmake
+    - curl
+    - gettext
+    - gimp
+    - gparted
+    - graphviz-devel
+    - htop
+    - imagemagick
+    - inkscape
+    - libmemcached-devel
+    - libwebp-devel
+    - lynx
+    - macchanger
+    - p7zip
+    - python3-devel
+    - python-devel
+    - unetbootin
+    - vlc
+    - wget
+    - xclip
+    - xml2
+    - zlib-devel
+    - libffi-devel
+    - openssl-devel
+    - pidgin
+    - docker
+
+

--- a/dev/playbooks/hosts
+++ b/dev/playbooks/hosts
@@ -1,0 +1,2 @@
+[home]
+localhost ansible_connection=local

--- a/dev/playbooks/roles/fedora-common-packages/tasks/main.yml
+++ b/dev/playbooks/roles/fedora-common-packages/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: update packages cache
+  yum: update_cache=yes
+  become: yes
+  become_method: sudo
+
+- name: upgrade all packages
+  yum: name=* state=latest
+  become: yes
+  become_method: sudo
+
+- name: ensure package list is installed
+  yum: name={{ item }} state=present
+  become: yes
+  become_method: sudo
+  with_items: "{{ packages_to_install }}"

--- a/dev/playbooks/roles/git/tasks/main.yml
+++ b/dev/playbooks/roles/git/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: ensure git is installed
+  yum: name=git state=present
+  become: yes
+  become_method: sudo
+
+- name: be sure git is configured
+  template: src=gitconfig.j2 dest={{ ansible_env.HOME }}/.gitconfig owner={{ ansible_user_id }}

--- a/dev/playbooks/roles/git/templates/gitconfig.j2
+++ b/dev/playbooks/roles/git/templates/gitconfig.j2
@@ -1,0 +1,10 @@
+[user]
+    name = {{ git_full_name }}
+    email = {{ git_email }}
+[alias]
+    lg = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
+    delete-merged-branches = "!git branch --merged master | grep -v master | xargs git branch -D"
+[pull]
+    rebase = true
+[push]
+    default = simple

--- a/dev/playbooks/roles/pycharm/defaults/main.yml
+++ b/dev/playbooks/roles/pycharm/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+
+pycharm_release_number: "2016.1.2"
+
+pycharm_version: "professional"
+

--- a/dev/playbooks/roles/pycharm/tasks/main.yml
+++ b/dev/playbooks/roles/pycharm/tasks/main.yml
@@ -1,0 +1,28 @@
+- name: ensure if {{ ansible_env.HOME }}/binaries/pycharm directory exists
+  file: path={{ ansible_env.HOME }}/binaries/pycharm state=directory mode=0755
+  register: pycharm_directory_exists
+
+- name: ensure aria2 download manager is installed
+  yum: name=aria2 state=present update_cache=yes cache_valid_time=300
+  become: yes
+  become_method: sudo
+
+- name: download Pycharm (280MB)
+  shell: aria2c -k 20M -x 10 -c --dir={{ ansible_env.HOME }}/binaries/pycharm --out=pycharm-{{ pycharm_version }}-{{ pycharm_release_number }}.tar.gz http://download.jetbrains.com/python/pycharm-{{ pycharm_version }}-{{ pycharm_release_number }}.tar.gz
+  args:
+    executable: /bin/bash
+
+
+- name: ensure pycharm is installed
+  unarchive: src={{ ansible_env.HOME }}/binaries/pycharm/pycharm-{{ pycharm_version }}-{{ pycharm_release_number }}.tar.gz dest={{ ansible_env.HOME }}/binaries/pycharm copy=no
+#  when: pycharm_directory_exists | changed
+  register: pycharm_extracted
+
+
+- name: ensure if {{ ansible_env.HOME }}/.local/share/applications directory exists
+  file: path={{ ansible_env.HOME }}/.local/share/applications state=directory mode=0755
+  register: applications_exists
+
+- name: ensure pycharm launcher is installed
+  template: src=jetbrains-pycharm.desktop.j2 dest={{ ansible_env.HOME }}/.local/share/applications/jetbrains-pycharm.desktop
+#  when: pycharm_extracted | changed and applications_exists | changed

--- a/dev/playbooks/roles/pycharm/templates/jetbrains-pycharm.desktop.j2
+++ b/dev/playbooks/roles/pycharm/templates/jetbrains-pycharm.desktop.j2
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=PyCharm
+Icon={{ ansible_env.HOME }}/binaries/pycharm/pycharm-{{ pycharm_release_number }}/bin/pycharm.png
+Exec="{{ ansible_env.HOME }}/binaries/pycharm/pycharm-{{ pycharm_release_number }}/bin/pycharm.sh" %f
+Comment=Develop with pleasure!
+Categories=Development;IDE;
+Terminal=false
+StartupWMClass=jetbrains-pycharm

--- a/dev/playbooks/workstation.yml
+++ b/dev/playbooks/workstation.yml
@@ -1,0 +1,11 @@
+
+- hosts:
+    - home
+
+  vars_files:
+    - "default_fedora_packages_to_install.yml"
+
+  roles:
+    - fedora-common-packages
+    - { role: git, git_full_name: "Your Name", git_email: "Your Email"}
+    - { role: pycharm, pycharm_version: "professional", pycharm_release_number: "2016.1.2" }


### PR DESCRIPTION
Working in progress, **DO NOT MERGE YET**, sent only to open the discussion.

add ansible playbooks to automatic configuration of a fedora23 development workstation for SatelliteQE team members

TODO:
- [x] Install basic fedora packages
- [x] Configure git
- [ ] Configure Python Environments
- [x] Install Pycharm
- [ ] Install other useful development tools
- [ ] Clone SatelliteQE repositories
- [ ] Configure SatelliteQE virtualenvs
- [ ] Install SatelliteQE projects
  # SatelliteQE Dev Environment Playbooks

The ansible playbooks to deploy Fedora 23 development machine
## install

Install Ansible

``` bash
wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
sudo -H python2 /tmp/get-pip.py -U
sudo -H pip install ansible
```
## Check
1. You forked SatelliteQE repositories to your own github account
   - Go to github and click **fork** button on the following repositories
     - SatelliteQE/robottelo
     - SatelliteQE/nailgun
     - SatelliteQE/automation-tools
2. You have your ssh-keys configured to access github from your local machine
   - `ssh-keygen`  generate a key with defaults, `cat ~/.ssh/id_rsa.pub` copy and paste the contents in github (settings/ssh-keys)
## Configure

Edit **workstation.yml** including your github username and email
## Run

``` bash
ansible-playbook workstation.yml --ask-sudo-pass
```
